### PR TITLE
Getting a made-up key returns the whole config object

### DIFF
--- a/etc.js
+++ b/etc.js
@@ -23,18 +23,11 @@ util.inherits(Etc, ProtoListDeep);
 
 Etc.prototype.get = function(key) {
   var conf = this.deepSnapshot;
-  var parts = key.split(this.delim);
+  if (typeof key === 'undefined') return conf;
 
-  parts.forEach(function(part) {
-    if (conf[part]) {
-      conf = conf[part];
-    }
-    else {
-      return undefined;
-    }
-  });
-
-  return conf;
+  return key.split(this.delim).reduce(function(prev, part) {
+    return typeof prev[part] !== 'undefined' ? prev[part] : undefined;
+  }, conf);
 };
 
 Etc.prototype.set = function(key, value) {

--- a/test/conf.js
+++ b/test/conf.js
@@ -49,7 +49,8 @@ describe('Configuration methods', function() {
     assert.deepEqual(conf.get('fruit'), {green: {apple: 'granny'}, red: {apple: 'fuji'}});
   });
 
-  it('made-up key returns null', function() {
-    assert.strictEqual(conf.get('blah'), null);
+  it('made-up key returns undefined', function() {
+    conf.set('foo', 'bar');
+    assert.strictEqual(conf.get('blah'), undefined);
   });
 });


### PR DESCRIPTION
also, avoids looking for keys if get() called without arguments.
