### PR TITLE
Fix custom delimiter in env()

### DIFF
--- a/etc.js
+++ b/etc.js
@@ -103,8 +103,8 @@ Etc.prototype.argv = function () {
 };
 
 Etc.prototype.env = function (prefix, delim) {
-  delim = delim || '_';
-  prefix = (prefix || 'app') + delim;
+  delim = delim || ':';
+  prefix = prefix || 'app_';
 
   var self = this;
   var len = prefix.length;

--- a/test/conf.js
+++ b/test/conf.js
@@ -73,12 +73,24 @@ describe('Configuration methods', function () {
     process.env['test_lang'] = 'en';
     process.env['test_user:name'] = 'Brian';
     process.env['test_user:handle'] = 'cpsubrian';
-    conf.env('test');
+    conf.env('test_');
     assert.deepEqual(conf.get('lang'), 'en');
     assert.deepEqual(conf.get('user'), {name: 'Brian', handle: 'cpsubrian'});
     delete process.env['test_lang'];
     delete process.env['test_user:name'];
     delete process.env['test_user:handle'];
+  });
+
+  it('can read conf from environment using custom delimiter', function () {
+    process.env['test_lang'] = 'fr';
+    process.env['test_user_name'] = 'Joe';
+    process.env['test_user_handle'] = 'joemc';
+    conf.env('test_', '_');
+    assert.deepEqual(conf.get('lang'), 'fr');
+    assert.deepEqual(conf.get('user'), {name: 'Joe', handle: 'joemc'});
+    delete process.env['test_lang'];
+    delete process.env['test_user_name'];
+    delete process.env['test_user_handle'];
   });
 
   it('can add conf using the `all` alias', function () {


### PR DESCRIPTION
This makes the custom delimiter in env() behave more logically. Previously, the delimiter's only purpose was to separate the prefix from the keys. With this change, you are now expected to provide the entire prefix, and the delimiter is what separates depth in keys (overriding the default delimiter).

A quick example on how this update changes the behavior:

**Previous Usage**

``` js
// Given the following environment vars:
//    app_user:name = Brian 
//    app_user:email = cpsubrian@gmail.com

conf.env('app');

conf.get('user');
// { name: 'Brian', email: 'cpsubrian@gmail.com'}
```

**New Usage**

``` js
// Given the following environment vars:
//    app_user:name = Brian 
//    app_user:email = cpsubrian@gmail.com

conf.env('app_');

conf.get('user');
// { name: 'Brian', email: 'cpsubrian@gmail.com'}
```

**Using a custom delimiter**

``` js
// Given the following environment vars:
//    app_user_name = Brian 
//    app_user_email = cpsubrian@gmail.com

conf.env('app_', '_');

conf.get('user');
// { name: 'Brian', email: 'cpsubrian@gmail.com'}
```
