### PR TITLE
Add Env parser parameter.

### DIFF
--- a/etc.js
+++ b/etc.js
@@ -102,7 +102,7 @@ Etc.prototype.argv = function () {
   return this;
 };
 
-Etc.prototype.env = function (prefix, delim) {
+Etc.prototype.env = function (prefix, delim, parser) {
   delim = delim || '_';
   prefix = prefix || 'app_';
 
@@ -111,8 +111,14 @@ Etc.prototype.env = function (prefix, delim) {
   var env = {};
 
   Object.keys(process.env).forEach(function (key) {
+    var value = process.env[key];
+    if (typeof parser === 'function') {
+      try {
+        value = parser(value);
+      } catch (e) {}
+    }
     if (key.indexOf(prefix) === 0) {
-      self.unflattenKey(env, key.substr(len), process.env[key], delim);
+      self.unflattenKey(env, key.substr(len), value, delim);
     }
   });
 

--- a/test/conf.js
+++ b/test/conf.js
@@ -93,6 +93,19 @@ describe('Configuration methods', function () {
     delete process.env['test_user__handle'];
   });
 
+  it('can read conf from environment using custom parser', function () {
+    process.env['test_flag'] = 'true';
+    process.env['test_number'] = '42';
+    process.env['test_invalid'] = '0.3foo';
+    conf.env('test_', '_', JSON.parse);
+    assert.deepEqual(conf.get('flag'), true);
+    assert.deepEqual(conf.get('number'), 42);
+    assert.deepEqual(conf.get('invalid'), '0.3foo');
+    delete process.env['test_flag'];
+    delete process.env['test_number'];
+    delete process.env['test_invalid'];
+  });
+
   it('can add conf using the `all` alias', function () {
     conf.all();
     assert.deepEqual(conf.get('fruit'), {green: {apple: 'granny'}, red: {apple: 'fuji'}});


### PR DESCRIPTION
When passing values via the environment, contrary to the other methods provided (json file, direct add/set, etc), all resulting values are strings. While the technical reasons for this are clear, it would be good to have a possibility to convert these values into the type they are intended to be.

The solution I propose is a very simple one: Add an optional parameter to the env loader, which is used as a parser. If not present, or the parser throws an error, the original value in its string type is used.
