### PR TITLE
Add parser to env and argv values.

### DIFF
--- a/etc.js
+++ b/etc.js
@@ -91,18 +91,18 @@ Etc.prototype.all = function () {
   return this.argv().env().etc().pkg();
 };
 
-Etc.prototype.argv = function () {
+Etc.prototype.argv = function (parser) {
   var self = this, args = {};
   if (optimist.argv) {
     Object.keys(optimist.argv).forEach(function (key) {
-      self.unflattenKey(args, key, optimist.argv[key]);
+      self.unflattenKey(args, key, self.parseValue(optimist.argv[key], parser));
     });
     this[this.mode](args);
   }
   return this;
 };
 
-Etc.prototype.env = function (prefix, delim) {
+Etc.prototype.env = function (prefix, delim, parser) {
   delim = delim || '_';
   prefix = prefix || 'app_';
 
@@ -112,7 +112,7 @@ Etc.prototype.env = function (prefix, delim) {
 
   Object.keys(process.env).forEach(function (key) {
     if (key.indexOf(prefix) === 0) {
-      self.unflattenKey(env, key.substr(len), process.env[key], delim);
+      self.unflattenKey(env, key.substr(len), self.parseValue(process.env[key], parser), delim);
     }
   });
 
@@ -211,6 +211,16 @@ Etc.prototype.etc = function (dir) {
   }
 
   return this;
+};
+
+Etc.prototype.parseValue = function (value, parser) {
+  parser = parser || JSON.parse;
+  if (typeof parser === 'function') {
+    try {
+      value = parser(value);
+    } catch (e) {}
+  }
+  return value;
 };
 
 Etc.prototype.parseJSON = function (filePath) {

--- a/test/conf.js
+++ b/test/conf.js
@@ -93,6 +93,22 @@ describe('Configuration methods', function () {
     delete process.env['test_user__handle'];
   });
 
+  it('can read conf from environment using parser', function () {
+    process.env['test_flag'] = 'true';
+    process.env['test_literal'] = 'Joe';
+    process.env['test_number'] = '0.4';
+    process.env['test_array'] = '[1, 1, 2, 3, 5, 8]';
+    conf.env('test_');
+    assert.deepEqual(conf.get('flag'), true);
+    assert.deepEqual(conf.get('literal'), 'Joe');
+    assert.deepEqual(conf.get('number'), 0.4);
+    assert.deepEqual(conf.get('array'), [1, 1, 2, 3, 5, 8]);
+    delete process.env['test_flag'];
+    delete process.env['test_literal'];
+    delete process.env['test_number'];
+    delete process.env['test_array'];
+  });
+
   it('can add conf using the `all` alias', function () {
     conf.all();
     assert.deepEqual(conf.get('fruit'), {green: {apple: 'granny'}, red: {apple: 'fuji'}});


### PR DESCRIPTION
Introduces an optional `parser` parameter to the `.env` and `.argv`
config loaders, which is used to parse incoming string values to
JavaScript literals.  If the parser throws an exception, the original
string value will be used.  The parser defaults to JSON.parse.
