### PR TITLE
update etc.folder to use path.resolve

### DIFF
--- a/etc.js
+++ b/etc.js
@@ -153,6 +153,7 @@ Etc.prototype.file = function (file, named, baseDir) {
 
 Etc.prototype.folder = function (dir) {
   var self = this;
+  dir = path.resolve(dir)
   var files = glob.sync(dir + '/**/*.*');
   files.forEach(function (file) {
     var rel = file.substr(dir.length).replace(/^\//, '');


### PR DESCRIPTION
this will fix some nasty errors for filename resolving

I had the problem of using "/../" in my code. It always cut of some part of the filename, because the path in glob doesn't include "/../". 
I switched from literal string concat to path.join, but maybe somebody else will stumble upon this small thing.